### PR TITLE
feat: custom API address

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ Example: `markdown-gpt-translator -m 4 -f 1000 learn/thinking-in-react.md`
 - `-i NUM`, `--interval=NUM`: Sets the API call interval.
 - `-o NAME`, `--out=NAME`: Explicitly sets the output file name. If set, the `OUT_SUFFIX` setting will be ignored.
 - `--out-suffix=NAME`: Output file suffix. See above.
-- `-a ADDRESS`, `--api-address=ADDRESS`: Sets custom API address.
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Example: `markdown-gpt-translator -m 4 -f 1000 learn/thinking-in-react.md`
 - `-i NUM`, `--interval=NUM`: Sets the API call interval.
 - `-o NAME`, `--out=NAME`: Explicitly sets the output file name. If set, the `OUT_SUFFIX` setting will be ignored.
 - `--out-suffix=NAME`: Output file suffix. See above.
+- `-a ADDRESS`, `--api-address=ADDRESS`: Sets custom API address.
 
 ## Limitations
 

--- a/env-example
+++ b/env-example
@@ -39,3 +39,7 @@ OPENAI_API_KEY="sk-xxxxxxxxxxxxxxxxxxxxxxxxxxx"
 
 # Suffixes to be added after the translated file.
 # OUTPUT_SUFFIX=""
+
+# Custom API address, to integrate with a third-party API service provider.
+# default is OpenAI's API endpoint: https://api.openai.com/v1
+# API_ADDRESS="https://xxxxx.com/v1"

--- a/src/api.ts
+++ b/src/api.ts
@@ -67,13 +67,14 @@ const limitCallRate = <T extends (...args: any[]) => Promise<any>>(
 };
 
 export type ConfigureApiOptions = {
+  apiAddress?: string;
   apiKey: string;
   rateLimit?: number;
   httpsProxy?: string;
 };
 
 const configureApiCaller = (options: ConfigureApiOptions) => {
-  const { apiKey, rateLimit = 0, httpsProxy } = options;
+  const { apiAddress = 'https://api.openai.com/v1', apiKey, rateLimit = 0, httpsProxy } = options;
 
   const callApi: ApiCaller = async (
     text,
@@ -86,7 +87,7 @@ const configureApiCaller = (options: ConfigureApiOptions) => {
     const ac = new AbortController();
 
     onStatus({ status: 'pending', lastToken: '' });
-    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    const response = await fetch(`${apiAddress}/chat/completions`, {
       agent,
       method: 'POST',
       headers: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import { translateMultiple } from './translate.js';
 
 const options = [
   { names: ['model', 'm'], type: 'string', help: 'Model to use.' },
+  { names: ['api-address', 'a'], type: 'string', help: 'Customized API address'},
   { names: ['fragment-size', 'f'], type: 'number', help: 'Fragment size.' },
   { names: ['temperature', 't'], type: 'number', help: 'Temperature.' },
   { names: ['interval', 'i'], type: 'number', help: 'API call interval.' },
@@ -67,6 +68,7 @@ const main = async () => {
   printStatus();
 
   const callApi = configureApiCaller({
+    apiAddress: config.apiAddress,
     apiKey: config.apiKey,
     rateLimit: config.apiCallInterval,
     httpsProxy: config.httpsProxy

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,6 @@ import { translateMultiple } from './translate.js';
 
 const options = [
   { names: ['model', 'm'], type: 'string', help: 'Model to use.' },
-  { names: ['api-address', 'a'], type: 'string', help: 'Customized API address'},
   { names: ['fragment-size', 'f'], type: 'number', help: 'Fragment size.' },
   { names: ['temperature', 't'], type: 'number', help: 'Temperature.' },
   { names: ['interval', 'i'], type: 'number', help: 'API call interval.' },

--- a/src/loadConfig.ts
+++ b/src/loadConfig.ts
@@ -7,6 +7,7 @@ import readTextFile from './readTextFile.js';
 const homeDir = os.homedir();
 
 export interface Config {
+  apiAddress: string | undefined;
   apiKey: string;
   prompt: string;
   model: string;
@@ -69,6 +70,7 @@ export const loadConfig = async (args: any): Promise<Config> => {
   if (!promptPath) throw new Error('Prompt file not found.');
 
   return {
+    apiAddress: args.api_address ?? conf.API_ADDRESS,
     apiKey: conf.OPENAI_API_KEY,
     prompt: await readTextFile(promptPath),
     model: resolveModelShorthand(args.model ?? conf.MODEL_NAME ?? 3),

--- a/src/loadConfig.ts
+++ b/src/loadConfig.ts
@@ -70,7 +70,7 @@ export const loadConfig = async (args: any): Promise<Config> => {
   if (!promptPath) throw new Error('Prompt file not found.');
 
   return {
-    apiAddress: args.api_address ?? conf.API_ADDRESS,
+    apiAddress: conf.API_ADDRESS,
     apiKey: conf.OPENAI_API_KEY,
     prompt: await readTextFile(promptPath),
     model: resolveModelShorthand(args.model ?? conf.MODEL_NAME ?? 3),


### PR DESCRIPTION
In order to support some third-party GPT API providers, I have added the startup parameters `-a` and the environment variable `API_ADDRESS` for **customizing the request address**.  

This is because obtaining official GPT API services can be extremely challenging in some countries and regions.