### PR TITLE
fix typo

### DIFF
--- a/src/loadConfig.ts
+++ b/src/loadConfig.ts
@@ -78,7 +78,7 @@ export const loadConfig = async (args: any): Promise<Config> => {
 
   return {
     apiEndpoint:
-      conf.API_ENDOPOINT ?? 'https://api.openai.com/v1/chat/completions',
+      conf.API_ENDPOINT ?? 'https://api.openai.com/v1/chat/completions',
     apiKey: conf.OPENAI_API_KEY,
     prompt: await readTextFile(promptPath),
     model: resolveModelShorthand(args.model ?? conf.MODEL_NAME ?? '3'),


### PR DESCRIPTION
In commit f4382cd1cfa2beeea16ff4dabab85e061118d340, the `apiAddress` is changed to `apiEndpoint`.

However, current `src/loadConfig.ts` contains a typo, 

```
  return {
    apiEndpoint:
      conf.API_ENDOPOINT ?? 'https://api.openai.com/v1/chat/completions',
```

This will cause very strange behavior (after set `API_ENDPOINT` in `.env`, this program still use`https://api.openai.com/v1/chat/completions`).

This PR fix this.