### PR TITLE
Change file output behavior to align with standard Linux tools

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -97,7 +97,7 @@ const main = async () => {
 
   let outFile = filePath;
   if (config.out) {
-    outFile = path.resolve(path.dirname(filePath), config.out);
+    outFile = path.resolve(config.baseDir, config.out);
   } else if (config.outSuffix) {
     outFile = outFile.replace(/\.[a-zA-Z0-9]+$/, '') + config.outSuffix;
   }


### PR DESCRIPTION
This pull request proposes a change to the file generation behavior of our program. 

Currently, when running `chatgpt-md-translator contents/a.md -o content_new/b.md` from directory `a` (without set BASE_DIR) , the new file is generated as follows:

```
a/
└── content/
    ├── a.md
    └── content_new/
        └── b.md
```

This PR changes that behavior so the new file is generated as follows:

```
a/
├── content/
│   └── a.md
└── content_new/
    └── b.md
```

The motivation for this change is to align our tool's behavior with that of most standard Linux tools. In general, command-line tools interpret paths as relative to the current working directory. For instance, when executing a command like `cp file1 file2`, `file2` is created in the current working directory, not in the directory where `file1` resides.

Our users, especially those familiar with Linux, may expect our tool to behave similarly. By changing this behavior, we make our tool more intuitive to use and consistent with user expectations. This should reduce confusion and improve overall user experience.
