### PR TITLE
Introduce OUTPUT_FILE_PATTERN

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,12 +87,23 @@ Code blocks usually don't need to be translated, so code blocks that are longer 
 
 Short code blocks (up to 5 lines by default) are sent as-is to give the API a better context for translation. If you want to replace all code blocks, specify `0`. If you don't want this feature (for example, if you want to translate comments in code examples), you can specify a large value like `1000`. But code blocks will never be split into fragments, so be mindful of the token limit!
 
-### Output File Name
+### Output File Name (`OUTPUT_FILE_PATTERN`)
 
-By default, the input file will be overwritten with the translated content. If you prefer to save the new content under a different name, you can do so in two ways:
+By default, the content of the input file will be overwritten with the translated content. If you prefer to save the new content in a different directory or under a different filename, you can specify a pattern to transform the input path into the output path.
 
-- You can explicitly specify the output file name in command line, like `-o translated.md` or `--out=translated.md`.
-- Alternatively, you can specify `OUT_SUFFIX` in the config file. The original extention will be removed, and this suffix will be added. For example, if you specify `"-es.md"` and the input file name is `"index.md"`, the translated file will be saved as `"index-es.md"`.
+For example, when the input file is `/projects/abc/docs/tutorial/index.md`, you can set `OUTPUT_FILE_PATTERN="{dir}/i18n/{basename}-es.md"` to write the translated content to `/projects/abc/docs/tutorial/i18n/index-es.md`. The following placeholders are available:
+
+- `{dir}`: `/projects/abc/docs/tutorial` (absolute directory path)
+- `{main}`: `/projects/abc/docs/tutorial/index` (entire path minus the extension)
+- `{filename}`: `index.md`
+- `{basename}`: `index` (the filename without the extension)
+- `{ext}`: `md`
+- When `BASE_DIR` is defined in the config file:
+  - `{basedir}`: `/projects/abc/docs` (the `BASE_DIR` itself)
+  - `{reldir}`: `tutorial` (relative to `BASE_DIR`)
+  - `{relmain}`: `tutorial/index` (relative to `BASE_DIR`)
+
+Alternatively, you can directly specify the output file name in command line, like `-o translated.md` or `--out=translated.md`. The path will be relative to the current directory (or `BASE_DIR` if it's defined in the config file).
 
 ## CLI Options
 
@@ -104,12 +115,11 @@ Example: `markdown-gpt-translator -m 4 -f 1000 learn/thinking-in-react.md`
 - `-f NUM`, `--fragment-size=NUM`: Sets the fragment size (in string length).
 - `-t NUM`, `--temperature=NUM`: Sets the "temperature", or the randomness of the output.
 - `-i NUM`, `--interval=NUM`: Sets the API call interval.
-- `-o NAME`, `--out=NAME`: Explicitly sets the output file name. If set, the `OUT_SUFFIX` setting will be ignored.
-- `--out-suffix=NAME`: Output file suffix. See above.
+- `-o NAME`, `--out=NAME`: Explicitly sets the output file name. If set, the `OUTPUT_FILE_PATTERN` setting will be ignored.
 
 ## Limitations and Pitfalls
 
-- Use only "Chat" models. InstructGPT models such as "text-davinci-001" are not supported.
+- Use only "Chat" models. Legacy InstructGPT models such as "text-davinci-001" are not supported.
 - This tool does not perform serious Markdown parsing for fragment splitting. The algorithm may fail on an atypical source file that has no or very few blank lines. However, this also means that most Markdown dialects can be handled without any configuration. If this tool makes mistakes for certain custom markups, it can likely be addressed with tweaking your prompt file.
 - Actually, this tool does not perform any Markdown-specific processing other than code block detection, so it may also handle plain text or Wiki-style documents.
 - The combination of this tool and GPT-4 should do 80% of the translation job, but be sure to review the result at your own responsibility. It sometimes ignores your instruction or outputs invalid Markdown, most of which are easily detectable and fixable with tools like VS Code's diff editor.

--- a/env-example
+++ b/env-example
@@ -14,7 +14,6 @@ OPENAI_API_KEY="sk-xxxxxxxxxxxxxxxxxxxxxxxxxxx"
 # =====================================
 
 # Base directory of the translated content.
-# If set, files paths including --out path will be relative to this.
 # BASE_DIR="/path/to/my/docs-project/content"
 
 # HTTPS Proxy (e.g, "https://proxy.example.com:8080")
@@ -38,8 +37,8 @@ OPENAI_API_KEY="sk-xxxxxxxxxxxxxxxxxxxxxxxxxxx"
 # sent to the API as-is for context.
 # CODE_BLOCK_PRESERVATION_LINES=5
 
-# Suffixes to be added after the translated file.
-# OUTPUT_SUFFIX=""
+# Transforms the input path to the output file path.
+# OUTPUT_FILE_PATTERN=""
 
 # Custom API address, to integrate with a third-party API service provider.
 # API_ENDPOINT="https://api.openai.com/v1/chat/completions"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "test": "npm run build && node --test lib/*.test.js"
+    "test": "tsx --test src/*.test.ts"
   },
   "keywords": [
     "cli",

--- a/src/fs-utils.test.ts
+++ b/src/fs-utils.test.ts
@@ -1,0 +1,65 @@
+import assert from 'node:assert';
+import { test } from 'node:test';
+import { extractPlaceholders, resolveOutFilePath } from './fs-utils.js';
+
+test('extractPlaceholders', () => {
+  const p1 = extractPlaceholders('/prj/src/tutorial/index.js', '/prj/src');
+  assert.deepStrictEqual(p1, {
+    dir: '/prj/src/tutorial',
+    main: '/prj/src/tutorial/index',
+    basename: 'index',
+    filename: 'index.js',
+    ext: 'js',
+    basedir: '/prj/src',
+    reldir: 'tutorial',
+    relmain: 'tutorial/index'
+  });
+
+  const p2 = extractPlaceholders('/path/to/foo', null);
+  assert.deepStrictEqual(p2, {
+    dir: '/path/to',
+    main: '/path/to/foo',
+    basename: 'foo',
+    filename: 'foo',
+    ext: ''
+  });
+});
+
+test('resolveOutFilePath', () => {
+  assert.equal(
+    resolveOutFilePath('/prj/src/tutorial/index.md', null, null),
+    '/prj/src/tutorial/index.md'
+  );
+
+  assert.equal(
+    resolveOutFilePath('/prj/src/tutorial/index.md', null, '/tmp/out.md'),
+    '/tmp/out.md'
+  );
+
+  assert.equal(
+    resolveOutFilePath(
+      '/prj/src/tutorial/index.md',
+      '/prj/src',
+      '{dir}/{basename}-ja.{ext}'
+    ),
+    '/prj/src/tutorial/index-ja.md'
+  );
+
+  assert.equal(
+    resolveOutFilePath(
+      '/prj/src/tutorial/index.md',
+      '/prj/src',
+      '{basedir}/i18n/ja/{relmain}-ja.{ext}'
+    ),
+    '/prj/src/i18n/ja/tutorial/index-ja.md'
+  );
+
+  assert.equal(
+    resolveOutFilePath(
+      '/prj/src/tutorial/index.md',
+      null,
+      '{basedir}/{dummy}/{test}'
+    ),
+    '{basedir}/{dummy}/{test}'
+  );
+});

--- a/src/fs-utils.ts
+++ b/src/fs-utils.ts
@@ -2,15 +2,19 @@ import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 
 // We use this to output a bit frindlier error
-
 export const readTextFile = async (filePath: string): Promise<string> => {
   try {
     return await fs.readFile(filePath, 'utf-8');
   } catch (e: any) {
-    if (e.code === 'ENOENT') {
-      throw new Error('File not found: ' + filePath);
-    } else {
-      throw e;
+    switch (e.code) {
+      case 'EISDIR':
+        throw new Error('The specified path is a directory: ' + filePath);
+      case 'ENOENT':
+        throw new Error('File not found: ' + filePath);
+      case 'EACCES':
+        throw new Error('Permission denied: ' + filePath);
+      default:
+        throw e;
     }
   }
 };

--- a/src/loadConfig.ts
+++ b/src/loadConfig.ts
@@ -11,14 +11,14 @@ export interface Config {
   apiKey: string;
   prompt: string;
   model: string;
-  baseDir: string;
+  baseDir: string | null;
   apiCallInterval: number;
   quiet: boolean;
   fragmentSize: number;
   temperature: number;
   codeBlockPreservationLines: number;
   out: string | null;
-  outSuffix: string | null;
+  outputFilePattern: string | null;
   httpsProxy?: string;
 }
 
@@ -60,7 +60,10 @@ const resolveModelShorthand = (model: string): string => {
   return shorthands[model] ?? model;
 };
 
-export const loadConfig = async (args: any): Promise<Config> => {
+export const loadConfig = async (args: {
+  [key: string]: any;
+}): Promise<{ config: Config; warnings: string[] }> => {
+  const warnings: string[] = [];
   const configPath = await findConfigFile();
   if (!configPath) throw new Error('Config file not found.');
   const conf = parse(await readTextFile(configPath));
@@ -76,13 +79,23 @@ export const loadConfig = async (args: any): Promise<Config> => {
     return isNaN(num) ? undefined : num;
   };
 
-  return {
+  const outSuffix: string | null =
+    conf.OUT_SUFFIX?.length > 0
+      ? conf.OUT_SUFFIX
+      : args.out_suffix?.length > 0
+      ? args.out_suffix
+      : null;
+  if (outSuffix) {
+    warnings.push('OUT_SUFFIX is deprecated. Use OUTPUT_FILE_PATTERN instead.');
+  }
+
+  const config = {
     apiEndpoint:
       conf.API_ENDPOINT ?? 'https://api.openai.com/v1/chat/completions',
     apiKey: conf.OPENAI_API_KEY,
     prompt: await readTextFile(promptPath),
     model: resolveModelShorthand(args.model ?? conf.MODEL_NAME ?? '3'),
-    baseDir: conf.BASE_DIR ?? process.cwd(),
+    baseDir: conf.BASE_DIR ?? null,
     apiCallInterval: toNum(args.interval) ?? toNum(conf.API_CALL_INTERVAL) ?? 0,
     quiet: args.quiet ?? process.stdout.isTTY === false,
     fragmentSize:
@@ -90,12 +103,16 @@ export const loadConfig = async (args: any): Promise<Config> => {
     temperature: toNum(args.temperature) ?? toNum(conf.TEMPERATURE) ?? 0.1,
     codeBlockPreservationLines: toNum(conf.CODE_BLOCK_PRESERVATION_LINES) ?? 5,
     out: args.out?.length > 0 ? args.out : null,
-    outSuffix:
-      conf.OUT_SUFFIX?.length > 0
-        ? conf.OUT_SUFFIX
-        : args.out_suffix?.length > 0
-        ? args.out_suffix
-        : null,
+    outputFilePattern:
+      (conf.OUTPUT_FILE_PATTERN?.length > 0
+        ? conf.OUTPUT_FILE_PATTERN
+        : null) ?? (outSuffix ? '{main}' + outSuffix : null),
     httpsProxy: conf.HTTPS_PROXY ?? process.env.HTTPS_PROXY
   };
+
+  if (config.outputFilePattern && !/{(\w+?)}/.test(config.outputFilePattern)) {
+    warnings.push('OUTPUT_FILE_PATTERN does not contain any placeholder.');
+  }
+
+  return { config, warnings };
 };


### PR DESCRIPTION
By default, the content of the input file will be overwritten with the translated content. This PR adds a method to specify the output file path based on the input path.

For example, when the input file is `/projects/abc/docs/tutorial/index.md`, you can set `OUTPUT_FILE_PATTERN="{dir}/i18n/{basename}-es.md"` to write the translated content to `/projects/abc/docs/tutorial/i18n/index-es.md`. The following placeholders are available:

- `{dir}`: `/projects/abc/docs/tutorial` (absolute directory path)
- `{main}`: `/projects/abc/docs/tutorial/index` (entire path minus the extension)
- `{filename}`: `index.md`
- `{basename}`: `index` (the filename without the extension)
- `{ext}`: `md`
- When `BASE_DIR` is defined in the config file:
  - `{basedir}`: `/projects/abc/docs` (the `BASE_DIR` itself)
  - `{reldir}`: `tutorial` (relative to `BASE_DIR`)
  - `{relmain}`: `tutorial/index` (relative to `BASE_DIR`)

Notes:

- This PR also deprecates `OUT_SUFFIX` option.
- For safety, we won't create a directory automatically.