### PR TITLE
Multiple file translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ By default, the content of the input file will be overwritten with the translate
 
 Alternatively, you can directly specify the output file name in command line, like `-o translated.md` or `--out=translated.md`. The path will be relative to the current directory (or `BASE_DIR` if it's defined in the config file).
 
+If you are translating many files, consider using the `OVERWRITE_POLICY` option as well to skip already translated files.
+
 ## CLI Options
 
 These can be used to override the settings in the config file.
@@ -111,6 +113,7 @@ Example: `markdown-gpt-translator -m 4 -f 1000 learn/thinking-in-react.md`
 - `-t NUM`, `--temperature=NUM`: Sets the "temperature", or the randomness of the output.
 - `-i NUM`, `--interval=NUM`: Sets the API call interval.
 - `-o NAME`, `--out=NAME`: Explicitly sets the output file name. If set, the `OUTPUT_FILE_PATTERN` setting will be ignored.
+- `-w ARG`, `--overwrite-policy=ARG`: Determines what happens when the output file already exists. One of "overwrite" (default), "skip", and "abort".
 
 ## Limitations and Pitfalls
 

--- a/env-example
+++ b/env-example
@@ -40,5 +40,8 @@ OPENAI_API_KEY="sk-xxxxxxxxxxxxxxxxxxxxxxxxxxx"
 # Transforms the input path to the output file path.
 # OUTPUT_FILE_PATTERN=""
 
+# What to do when the output file already exists. One of "overwite", "skip" and "abort".
+# OVERWRITE_POLICY="overwrite"
+
 # Custom API address, to integrate with a third-party API service provider.
 # API_ENDPOINT="https://api.openai.com/v1/chat/completions"

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,7 +106,9 @@ const main = async () => {
   if (args.help || args._args.length < 1) {
     if (args._args.length < 1)
       console.log(pc.red('No input files are specified.'));
-    console.log(pc.yellow('Usage: chatgpt-md-translator [options] <file>'));
+    console.log(
+      pc.yellow('Usage: chatgpt-md-translator [options] <file> [<file>...]')
+    );
     console.log(parser.help());
     console.log('Docs: https://github.com/smikitky/chatgpt-md-translator\n');
     return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,14 +41,7 @@ const translateFile = async (
 
   console.log(pc.cyan(`Translating: ${inFile}`));
   if (inFile !== outFile) console.log(pc.cyan(`To: ${outFile}`));
-
-  console.log(
-    pc.bold('Model:'),
-    config.model,
-    pc.bold('Temperature:'),
-    String(config.temperature),
-    '\n'
-  );
+  console.log(''); // empty line
 
   const printStatus = () => {
     if (config.quiet) return;
@@ -82,7 +75,7 @@ const translateFile = async (
 
   await fs.writeFile(outFile, finalResult, 'utf-8');
   console.log(pc.green(`Translation completed in ${formatTime(elapsedTime)}.`));
-  console.log(`File saved as ${outFile}.`);
+  console.log(`File saved as ${outFile}.\n`);
 };
 
 const options = [
@@ -145,6 +138,13 @@ const main = async () => {
 
     pathMap.set(inFile, outFile);
   }
+
+  console.log(
+    pc.bold('Model:'),
+    config.model,
+    pc.bold('Temperature:'),
+    String(config.temperature)
+  );
 
   for (const [inFile, outFile] of pathMap) {
     try {

--- a/src/utils/error-utils.ts
+++ b/src/utils/error-utils.ts
@@ -3,7 +3,7 @@ import typeUtils from 'node:util/types';
 export const isNodeException = (
   error: unknown
 ): error is NodeJS.ErrnoException => {
-  return typeUtils.isNativeError(error);
+  return typeUtils.isNativeError(error) && 'code' in error && 'errno' in error;
 };
 
 export const isMessageError = (


### PR DESCRIPTION
With this PR, you will be able to translate multiple files in a single command, as shown below:

```
chatgpt-md-translator file1.md file2.md file3.md

# Or using shell expansion
chatgpt-md-translator learn/{hello-world,next-step,advanced}.md
```

Currently, input files are processed sequentially, one after the other, rather than simultaneously. To implement parallel processing, we need to consider several factors, including how to display progress and manage API rate limits.

Furthermore, this PR introduces the `--overwrite-policy`/`-w` option, which allows you to specify what happens if the output file already exists. The available settings are `overwrite` (default), `skip`, and `abort`. You can use this option to prevent unintended overwriting of source files, and enable resuming translations of multiple files without starting over.

Even if an error occurs during the translation of one of the files, we will continue with the next file. By retrying the same command with `-w skip`, you can retry the translation of only the failed files.