### PR TITLE
Support env fallback when config file is missing and document OPENAI_API_KEY usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ This tool itself is free, but you will be charged according to [OpenAI's pricing
 
    At least, you need to specify your API key as `OPENAI_API_KEY`.
 
+   > Tip: If you don't want to create a config file, you can set `OPENAI_API_KEY` as an environment variable and the CLI will fall back to it. All other settings will use defaults unless you pass CLI options.
+
 5. Create a **prompt** file. You can copy this [`prompt-example.md`](https://raw.githubusercontent.com/smikitky/markdown-gpt-translator/main/prompt-example.md) to one of the following locations and edit its contents. At least, you need to specify the language name. The contents of this file will be included in each API call, so you can write instructions to ChatGPT in a natural language.
 
    - `$CWD/prompt.md`

--- a/src/loadConfig.ts
+++ b/src/loadConfig.ts
@@ -84,10 +84,22 @@ export const loadConfig = async (args: {
 }): Promise<{ config: Config; warnings: string[] }> => {
   const warnings: string[] = [];
   const configPath = await findConfigFile();
-  if (!configPath) throw new Error('Config file not found.');
-  const conf = parse(await readTextFile(configPath));
+  let conf: Record<string, string | undefined>;
+
+  if (configPath) {
+    conf = parse(await readTextFile(configPath));
+  } else {
+    conf = { ...process.env };
+    if (!conf.OPENAI_API_KEY) {
+      throw new Error('Config file not found and OPENAI_API_KEY is not set.');
+    }
+    warnings.push(
+      'Config file not found. Falling back to environment variables.'
+    );
+  }
+
   if (!conf.OPENAI_API_KEY) {
-    throw new Error('OPENAI_API_KEY is not set in config file.');
+    throw new Error('OPENAI_API_KEY is not set in config or environment.');
   }
 
   const promptPath = await findPromptFile();


### PR DESCRIPTION
This pull request improves the configuration loading process by allowing users to run the CLI tool without a config file, as long as the required `OPENAI_API_KEY` is set as an environment variable. The documentation is also updated to reflect this new behavior.

Configuration loading improvements:

* Updated `loadConfig` in `src/loadConfig.ts` to fall back to environment variables (specifically `OPENAI_API_KEY`) if a config file is not found, and added a warning when this fallback occurs.

Documentation update:

* Updated the `README.md` to inform users that they can set `OPENAI_API_KEY` as an environment variable instead of creating a config file, and that all other settings will use defaults unless specified via CLI options.